### PR TITLE
chore: add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.github/
+example/
+.gitignore
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
 ENV AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
 ENV AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
 
-COPY requirements.txt template.yaml samconfig.toml ./
+COPY . .
 RUN pip install --upgrade pip \
     && pip install -r requirements.txt -t layer/python/lib/python3.12/site-packages/
 


### PR DESCRIPTION
This commit adds .dockerignore to upload README and LICENSE file for AWS Serverless Application Repository